### PR TITLE
Fix broken link to Pkg tests

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,7 +20,7 @@ The `Test` module provides simple *unit testing* functionality. Unit testing is 
 see if your code is correct by checking that the results are what you expect. It can be helpful
 to ensure your code still works after you make changes, and can be used when developing as a way
 of specifying the behaviors your code should have when complete. You may also want to look at the
-documentation for [adding tests to your Julia Package](https://pkgdocs.julialang.org/dev/creating-packages/#Adding-tests-to-the-package).
+documentation for [adding tests to your Julia Package]([https://pkgdocs.julialang.org/dev/creating-packages/#Adding-tests-to-the-package](https://docs.julialang.org/en/v1.11-dev/tutorials/creating-packages/#adding-tests-to-packages)).
 
 Simple unit testing can be performed with the `@test` and `@test_throws` macros:
 


### PR DESCRIPTION
This link is broken as of https://github.com/JuliaLang/Pkg.jl/pull/3690 and https://github.com/JuliaLang/julia/pull/52102

I am not sure it is the best option to point to 1.11-dev.