### PR TITLE
Add option to make `verbose = true` apply recursively to nested test sets

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -151,10 +151,10 @@ This can be used to allow for factorization of test sets, making it easier to ru
 test sets by running the associated functions instead.
 Note that in the case of functions, the test set will be given the name of the called function.
 In the event that a nested test set has no failures, as happened here, it will be hidden in the
-summary, unless the `verbose=true` option is passed:
+summary:
 
 ```jldoctest testfoo; filter = r"[0-9\.]+s"
-julia> @testset verbose = true "Foo Tests" begin
+julia> @testset "Foo Tests" begin
            @testset "Animals" begin
                @test foo("cat") == 9
                @test foo("dog") == foo("cat")
@@ -166,10 +166,6 @@ julia> @testset verbose = true "Foo Tests" begin
        end;
 Test Summary: | Pass  Total  Time
 Foo Tests     |    8      8  0.0s
-  Animals     |    2      2  0.0s
-  Arrays 1    |    2      2  0.0s
-  Arrays 2    |    2      2  0.0s
-  Arrays 3    |    2      2  0.0s
 ```
 
 If we do have a test failure, only the details for the failed test sets will be shown:
@@ -199,6 +195,66 @@ Foo Tests     |    3     1      4  0.0s
   Animals     |    2            2  0.0s
   Arrays      |    1     1      2  0.0s
 ERROR: Some tests did not pass: 3 passed, 1 failed, 0 errored, 0 broken.
+```
+
+You can use the `verbose` option to show results even for test sets that pass.
+`verbose=true` (or equivalently `verbose=1`) displays results only for the top level of
+nested sets:
+
+```julia-repl; filter = r"[0-9\.]+s"
+julia> @testset "Foo Tests" verbose = true begin
+           @testset "Animals" begin
+               @testset "Felines" begin
+                   @test foo("cat") == 9
+               end
+               @testset "Canines" begin
+                   @test foo("dog") == 9
+               end
+           end
+           @testset "Arrays" begin
+               @testset "zeros" begin
+                   @test foo(zeros(2)) == 4
+               end
+               @testset "fill" begin
+                   @test foo(fill(1.0, 4)) == 16
+               end
+           end
+       end;
+Test Summary: | Pass  Total  Time
+Foo Tests     |    4      4  0.0s
+  Animals     |    2      2  0.0s
+  Arrays      |    2      2  0.0s
+```
+
+whereas `verbose=2` will apply to all nested test sets:
+
+```julia-repl; filter = r"[0-9\.]+s"
+julia> @testset "Foo Tests" verbose = 2 begin
+           @testset "Animals" begin
+               @testset "Felines" begin
+                   @test foo("cat") == 9
+               end
+               @testset "Canines" begin
+                   @test foo("dog") == 9
+               end
+           end
+           @testset "Arrays" begin
+               @testset "zeros" begin
+                   @test foo(zeros(2)) == 4
+               end
+               @testset "fill" begin
+                   @test foo(fill(1.0, 4)) == 16
+               end
+           end
+       end;
+Test Summary: | Pass  Total  Time
+Foo Tests     |    4      4  0.0s
+  Animals     |    2      2  0.0s
+    Felines   |    1      1  0.0s
+    Canines   |    1      1  0.0s
+  Arrays      |    2      2  0.0s
+    zeros     |    1      1  0.0s
+    fill      |    1      1  0.0s
 ```
 
 ## Testing Log Statements

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1200,72 +1200,149 @@ let ex = :(something_complex + [1, 2, 3])
 end
 
 @testset "verbose option" begin
-    expected = r"""
-    Test Summary:             | Pass  Total  Time
-    Parent                    |    9      9  \s*\d*.\ds
-      Child 1                 |    3      3  \s*\d*.\ds
-        Child 1.1 (long name) |    1      1  \s*\d*.\ds
-        Child 1.2             |    1      1  \s*\d*.\ds
-        Child 1.3             |    1      1  \s*\d*.\ds
-      Child 2                 |    3      3  \s*\d*.\ds
-      Child 3                 |    3      3  \s*\d*.\ds
-        Child 3.1             |    1      1  \s*\d*.\ds
-        Child 3.2             |    1      1  \s*\d*.\ds
-        Child 3.3             |    1      1  \s*\d*.\ds
-    """
-
-    mktemp() do f, _
-        write(f,
+    @testset "verbose = true" begin
+        expected = r"""
+        Test Summary:             | Pass  Total  Time
+        Parent                    |    9      9  \s*\d*.\ds
+          Child 1                 |    3      3  \s*\d*.\ds
+            Child 1.1 (long name) |    1      1  \s*\d*.\ds
+            Child 1.2             |    1      1  \s*\d*.\ds
+            Child 1.3             |    1      1  \s*\d*.\ds
+          Child 2                 |    3      3  \s*\d*.\ds
+          Child 3                 |    3      3  \s*\d*.\ds
+            Child 3.1             |    1      1  \s*\d*.\ds
+            Child 3.2             |    1      1  \s*\d*.\ds
+            Child 3.3             |    1      1  \s*\d*.\ds
         """
-        using Test
 
-        @testset "Parent" verbose = true begin
-            @testset "Child 1" verbose = true begin
-                @testset "Child 1.1 (long name)" begin
-                    @test 1 == 1
+        mktemp() do f, _
+            write(f,
+            """
+            using Test
+
+            @testset "Parent" verbose = true begin
+                @testset "Child 1" verbose = 1 begin
+                    @testset "Child 1.1 (long name)" begin
+                        @test 1 == 1
+                    end
+
+                    @testset "Child 1.2" begin
+                        @test 1 == 1
+                    end
+
+                    @testset "Child 1.3" begin
+                        @test 1 == 1
+                    end
                 end
 
-                @testset "Child 1.2" begin
-                    @test 1 == 1
+                @testset "Child 2" begin
+                    @testset "Child 2.1" begin
+                        @test 1 == 1
+                    end
+
+                    @testset "Child 2.2" begin
+                        @test 1 == 1
+                    end
+
+                    @testset "Child 2.3" begin
+                        @test 1 == 1
+                    end
                 end
 
-                @testset "Child 1.3" begin
-                    @test 1 == 1
+                @testset "Child 3" verbose = true begin
+                    @testset "Child 3.1" begin
+                        @test 1 == 1
+                    end
+
+                    @testset "Child 3.2" begin
+                        @test 1 == 1
+                    end
+
+                    @testset "Child 3.3" begin
+                        @test 1 == 1
+                    end
                 end
             end
-
-            @testset "Child 2" begin
-                @testset "Child 2.1" begin
-                    @test 1 == 1
-                end
-
-                @testset "Child 2.2" begin
-                    @test 1 == 1
-                end
-
-                @testset "Child 2.3" begin
-                    @test 1 == 1
-                end
-            end
-
-            @testset "Child 3" verbose = true begin
-                @testset "Child 3.1" begin
-                    @test 1 == 1
-                end
-
-                @testset "Child 3.2" begin
-                    @test 1 == 1
-                end
-
-                @testset "Child 3.3" begin
-                    @test 1 == 1
-                end
-            end
+            """)
+            cmd    = `$(Base.julia_cmd()) --startup-file=no --color=no $f`
+            result = read(pipeline(ignorestatus(cmd), stderr=devnull), String)
+            @test occursin(expected, result)
         end
-        """)
-        cmd    = `$(Base.julia_cmd()) --startup-file=no --color=no $f`
-        result = read(pipeline(ignorestatus(cmd), stderr=devnull), String)
-        @test occursin(expected, result)
+    end
+
+    @testset "verbose = 2" begin
+        expected = r"""
+        Test Summary:             \| Pass  Total  Time
+        Parent                    \|    9      9  \s*\d*\.\ds
+          Child 1                 \|    3      3  \s*\d*\.\ds
+            Child 1\.1 \(long name\) \|    2      2  \s*\d*\.\ds
+            Child 1\.2             \|    1      1  \s*\d*\.\ds
+          Child 2                 \|    3      3  \s*\d*\.\ds
+            Child 2\.1             \|    1      1  \s*\d*\.\ds
+              Child 2\.1\.1         \|    1      1  \s*\d*\.\ds
+            Child 2\.2             \|    1      1  \s*\d*\.\ds
+            Child 2\.3             \|    1      1  \s*\d*\.\ds
+          Child 3                 \|    3      3  \s*\d*\.\ds
+        """
+
+        mktemp() do f, _
+            write(f,
+            """
+            using Test
+
+            @testset "Parent" verbose = 2 begin
+                # Setting the verbosity to just 1 overrides the inherited, higher level of 2.
+                @testset "Child 1" verbose = 1 begin
+                    @testset "Child 1.1 (long name)" begin
+                        @testset "Child 1.1.1" begin
+                            @test 1 == 1
+                        end
+
+                        @testset "Child 1.1.2" begin
+                            @test 1 == 1
+                        end
+                    end
+
+                    @testset "Child 1.2" begin
+                        @test 1 == 1
+                    end
+                end
+
+                @testset "Child 2" begin
+                    @testset "Child 2.1" begin
+                        @testset "Child 2.1.1" begin
+                            @test 1 == 1
+                        end
+                    end
+
+                    @testset "Child 2.2" begin
+                        @test 1 == 1
+                    end
+
+                    @testset "Child 2.3" begin
+                        @test 1 == 1
+                    end
+                end
+
+                @testset "Child 3" verbose = false begin
+                    @testset "Child 3.1" begin
+                        @test 1 == 1
+                    end
+
+                    @testset "Child 3.2" begin
+                        @test 1 == 1
+                    end
+
+                    @testset "Child 3.3" begin
+                        @test 1 == 1
+                    end
+                end
+            end
+            """)
+            cmd    = `$(Base.julia_cmd()) --startup-file=no --color=no $f`
+            result = read(pipeline(ignorestatus(cmd), stderr=devnull), String)
+            @test occursin(expected, result)
+        end
     end
 end
 


### PR DESCRIPTION
I wanted a feature where `verbose = true` would apply to nested test sets all the way down the nesting, so I made it. Any interest in having this as part of `DefaultTestSet`? I didn't discuss this with anyone before hand, so "we don't want this, please close" is a valid response.

I wasn't sure about the best interface. I went with `verbose = 2`, but happy to consider e.g. `verbose = :recursive`. Currently `verbose = 1` is equivalent to `verbose = true`.

I'm leaving this as a draft because it currently breaks the `DefaultTestSet` constructors: If someone uses the "full" inner constructor with a `Bool` for `verbose` it'll error. `DefaultTestSet` isn't exported, but I would still like to fix that. I'll pause here to get comments though before implementing the fix.